### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ detection = fireeyepy.Detection(key=api_key)
 ```python
 response = detection.submit_file(
   files={
-    "file": ('filename', open('./path/to/filename', 'r'))
+    "file": ('filename', open('./path/to/filename', 'rb'))
   }
 )
 ```


### PR DESCRIPTION
Change the file open mode from 'r' to 'rb' so files are read as binary instead of text.  This allows all files, including images and executables, to be read and submitted to the API, not just text files.  This fixes issue #2